### PR TITLE
[eel] Replace usages of `java.io.File` with `java.nio.file.Path` where possible #SCL-23310

### DIFF
--- a/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/CompilationInfo.scala
+++ b/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/CompilationInfo.scala
@@ -1,9 +1,9 @@
 package org.jetbrains.plugins.scala.indices.protocol
 
-import java.io.File
+import java.nio.file.Path
 
 trait CompilationInfo {
-  def removedSources: Set[File]
+  def removedSources: Set[Path]
   def generatedClasses: Set[CompiledClass]
   def startTimestamp: Long
 

--- a/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/CompiledClass.scala
+++ b/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/CompiledClass.scala
@@ -1,5 +1,5 @@
 package org.jetbrains.plugins.scala.indices.protocol
 
-import java.io.File
+import java.nio.file.Path
 
-final case class CompiledClass(source: File, output: File)
+final case class CompiledClass(source: Path, output: Path)

--- a/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/DomainDefaultJsonProtocol.scala
+++ b/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/DomainDefaultJsonProtocol.scala
@@ -1,15 +1,16 @@
 package org.jetbrains.plugins.scala.indices.protocol
 
-import java.io.File
-
 import spray.json._
 
+import java.nio.file.{Path, Paths}
+
 trait DomainDefaultJsonProtocol extends DefaultJsonProtocol {
-  implicit val fileJsonFormat: JsonFormat[File] = new JsonFormat[File] {
-    override def read(json: JsValue): File = json match {
-      case JsString(path) => new File(path)
+  implicit val pathJsonFormat: JsonFormat[Path] = new JsonFormat[Path] {
+    override def read(json: JsValue): Path = json match {
+      case JsString(path) => Paths.get(path)
       case x              => deserializationError("Expected file path as JsString, but got " + x)
     }
-    override def write(file: File): JsValue = file.getPath.toJson
+
+    override def write(path: Path): JsValue = path.toAbsolutePath.normalize().toString.toJson
   }
 }

--- a/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/jps/JpsCompilationInfo.scala
+++ b/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/jps/JpsCompilationInfo.scala
@@ -1,12 +1,12 @@
 package org.jetbrains.plugins.scala.indices.protocol.jps
 
-import java.io.File
-
 import org.jetbrains.plugins.scala.indices.protocol.{CompilationInfo, CompiledClass}
+
+import java.nio.file.Path
 
 final case class JpsCompilationInfo(
   affectedModules:               Set[String],
-  override val removedSources:   Set[File],
+  override val removedSources:   Set[Path],
   override val generatedClasses: Set[CompiledClass],
   override val startTimestamp:   Long
 ) extends CompilationInfo

--- a/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/sbt/Locking.scala
+++ b/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/sbt/Locking.scala
@@ -1,22 +1,32 @@
 package org.jetbrains.plugins.scala.indices.protocol.sbt
 
-import java.io.{File, IOException, RandomAccessFile}
+import java.io.{IOException, RandomAccessFile}
 import java.nio.channels.FileLock
-import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+import java.nio.file.{Files, Path}
+import java.util.concurrent.ConcurrentHashMap
 
 object Locking {
   private[this] final case class LockData(raf: RandomAccessFile, lock: FileLock)
-  private[this] val locks: ConcurrentMap[File, LockData] = new ConcurrentHashMap[File, LockData]
+
+  private[this] val locks: ConcurrentHashMap[Path, LockData] = new ConcurrentHashMap()
 
   private[this] type Logger = String => Unit
   private[this] val noopLogger: Logger = Function.const(())
 
-  def lockFile(compilationInfoDir: File): File =
-    new File(compilationInfoDir, ".sbt-idea-lock")
+  def lockFile(compilationInfoDir: Path): Path =
+    compilationInfoDir.resolve(".sbt-idea-lock")
 
-  def lock(lockFile: File)(log: Logger = noopLogger): FileLock = {
-    if (lockFile.getParentFile.exists() || lockFile.getParentFile.mkdirs()) {
-      val raf = new RandomAccessFile(lockFile, "rw")
+  private def mkdirs(dir: Path): Boolean =
+    try {
+      Files.createDirectories(dir)
+      true
+    } catch {
+      case _: IOException => false
+    }
+
+  def lock(lockFile: Path)(log: Logger = noopLogger): FileLock = {
+    if (Files.exists(lockFile.getParent) || mkdirs(lockFile.getParent)) {
+      val raf = new RandomAccessFile(lockFile.toFile, "rw")
 
       try {
         log(s"Acquiring lock on file $lockFile ...")
@@ -32,7 +42,7 @@ object Locking {
     } else throw new RuntimeException("Unable to create lock file.")
   }
 
-  def unlock(lockFile: File)(log: Logger = noopLogger): Unit = {
+  def unlock(lockFile: Path)(log: Logger = noopLogger): Unit = {
     val data = locks.get(lockFile)
     if (data == null) {
       throw new IllegalArgumentException(s"Trying to unlock non-locked file $lockFile.")
@@ -42,10 +52,12 @@ object Locking {
         log(s"Releasing lock on file $lockFile.")
         data.lock.release()
         data.raf.close()
-      } catch { case e: IOException => e.printStackTrace() }
+      } catch {
+        case e: IOException => e.printStackTrace()
+      }
   }
 
-  implicit class FileLockingExt(val dir: File) extends AnyVal {
+  implicit class FileLockingExt(val dir: Path) extends AnyVal {
     def lock(log: Logger = noopLogger): Unit = {
       val lockF = lockFile(dir)
       Locking.lock(lockF)(log)

--- a/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/sbt/SbtCompilationInfo.scala
+++ b/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/sbt/SbtCompilationInfo.scala
@@ -1,15 +1,15 @@
 package org.jetbrains.plugins.scala.indices.protocol.sbt
 
-import java.io.File
-
 import org.jetbrains.plugins.scala.indices.protocol.{CompilationInfo, CompiledClass}
+
+import java.nio.file.Path
 
 final case class SbtCompilationInfo(
   projectId:                     String,
   isIncremental:                 Boolean,
   scalaVersion:                  String,
   configuration:                 Configuration,
-  override val removedSources:   Set[File],
+  override val removedSources:   Set[Path],
   override val generatedClasses: Set[CompiledClass],
   override val startTimestamp:   Long
 ) extends CompilationInfo

--- a/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/sbt/package.scala
+++ b/protocol/src/main/scala/org/jetbrains/plugins/scala/indices/protocol/sbt/package.scala
@@ -1,6 +1,5 @@
 package org.jetbrains.plugins.scala.indices.protocol
 
-import java.io.File
 import java.nio.file.Path
 
 package object sbt {
@@ -8,9 +7,9 @@ package object sbt {
   def compilationInfoFilePrefix: String = "compilation-info"
   def ideaACK: String                   = "ack"
 
-  def compilationInfoBaseDir(thisBuildBase: File): Path =
-    thisBuildBase.toPath.resolve(s"project/target/$compilationInfoDirName")
+  def compilationInfoBaseDir(thisBuildBase: Path): Path =
+    thisBuildBase.resolve(s"project/target/$compilationInfoDirName")
 
-  def projectCompilationInfoDir(thisBuildBase: File, projectId: String): Path =
+  def projectCompilationInfoDir(thisBuildBase: Path, projectId: String): Path =
     compilationInfoBaseDir(thisBuildBase).resolve(projectId)
 }

--- a/sbt-idea-compiler-indices/src/main/scala/org/jetbrains/sbt/indices/IntellijIndexer.scala
+++ b/sbt-idea-compiler-indices/src/main/scala/org/jetbrains/sbt/indices/IntellijIndexer.scala
@@ -24,7 +24,7 @@ object IntellijIndexer {
   }
 
   def compilationInfoDir(base: File, projectId: String): File =
-    projectCompilationInfoDir(base, projectId).toFile
+    projectCompilationInfoDir(base.toPath, projectId).toFile
 
   def isIdeaProject(base: File): Boolean = Files.isDirectory(base.toPath.resolve(".idea"))
 
@@ -74,7 +74,7 @@ object IntellijIndexer {
 
       classes.flatMap { clsFile =>
         val source = relations.produced(clsFile).headOption
-        source.map(CompiledClass(_, clsFile))
+        source.map(f => CompiledClass(f.toPath, clsFile.toPath))
       }(collection.breakOut)
     }
 
@@ -90,7 +90,7 @@ object IntellijIndexer {
       isIncremental,
       scalaVersion,
       configuration,
-      deletedSources,
+      deletedSources.map(_.toPath),
       generatedClasses,
       timestamp
     )

--- a/sbt-idea-compiler-indices/src/main/scala/org/jetbrains/sbt/indices/SbtIntellijIndicesPlugin.scala
+++ b/sbt-idea-compiler-indices/src/main/scala/org/jetbrains/sbt/indices/SbtIntellijIndicesPlugin.scala
@@ -56,7 +56,7 @@ object SbtIntellijIndicesPlugin extends AutoPlugin { self =>
         val compilationId   = UUID.randomUUID()
         val itype           = incrementalityType.value
         val version         = scalaBinaryVersion.value
-        val infoDir         = compilationInfoDir(buildBaseDir, s"$projectId-$configurationId")
+        val infoDir         = compilationInfoDir(buildBaseDir, s"$projectId-$configurationId").toPath
         val port            = ideaPort.value
 
         infoDir.lock(log = log.debug(_))
@@ -92,7 +92,7 @@ object SbtIntellijIndicesPlugin extends AutoPlugin { self =>
               projectId,
               version,
               itype,
-              infoDir,
+              infoDir.toFile,
               pconfig,
               compilationStartTimestamp,
               compilationId
@@ -131,7 +131,7 @@ object SbtIntellijIndicesPlugin extends AutoPlugin { self =>
     inConfig(Compile)(perConfig) ++ inConfig(Test)(perConfig) ++ Seq(
       cleanFiles += {
         val base = (baseDirectory in ThisBuild).value
-        compilationInfoBaseDir(base).toFile
+        compilationInfoBaseDir(base.toPath).toFile
       },
       commands += rebuildIndices
     )


### PR DESCRIPTION
- The changes to the `sbt-idea-compiler-indices` sbt plugin are superficial, to allow the project to be compiled.
- The sbt plugin is currently not distributed with the Scala plugin, and bytecode indices cannot be used with sbt shell.
- The sbt plugin needs to be correctly cross compiled between sbt 0.13, <= 1.2 and > 1.3, because of binary incompatibilities in the Zinc library.
- Furthermore, the sbt plugin needs to be fixed for compilation pipelining in the latest versions of sbt.
- This work has been postponed.